### PR TITLE
Add smart ball simulation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# BasketBall
+# BasketBall Simulation
+
+This repository implements a simple digital twin of a magnetically assisted
+basketball shot. The `smart_ball` package models the ball, hoop and magnetic
+force. A demonstration script compares a normal trajectory with one influenced
+by a current running through the hoop.
+
+## Running the demo
+
+Install dependencies (if needed):
+
+```bash
+pip install numpy matplotlib
+```
+
+Run the simulation and display the trajectories:
+
+```bash
+python scripts/run_simulation.py
+```

--- a/scripts/run_simulation.py
+++ b/scripts/run_simulation.py
@@ -1,0 +1,46 @@
+"""Run a demonstration of the magnetically assisted smart ball."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+
+from smart_ball import Ball, Hoop, simulate
+
+
+def main() -> None:
+    # initial state
+    initial_pos = (0.0, 2.0)
+    initial_vel = (8.0, 8.0)
+
+    # hoop definition
+    hoop = Hoop(center=(5.0, 3.0), current=400.0)
+
+    dt = 0.01
+    t_max = 3.0
+
+    # normal shot
+    normal_ball = Ball(initial_pos, initial_vel, susceptibility=0.05)
+    traj_normal, score_normal = simulate(normal_ball, hoop, dt, t_max, magnet=False)
+
+    # magnet assisted
+    magnet_ball = Ball(initial_pos, initial_vel, susceptibility=0.05)
+    traj_magnet, score_magnet = simulate(magnet_ball, hoop, dt, t_max, magnet=True)
+
+    # Plotting
+    plt.plot(traj_normal[:, 0], traj_normal[:, 1], label="normal shot")
+    plt.plot(traj_magnet[:, 0], traj_magnet[:, 1], label="magnet assisted")
+    plt.scatter([hoop.center[0]], [hoop.center[1]], color="black", zorder=5)
+    plt.legend()
+    plt.xlabel("x (m)")
+    plt.ylabel("y (m)")
+    plt.title("Smart ball trajectories")
+    plt.ylim(0, 5)
+    plt.grid(True)
+    plt.show()
+
+    print(f"Scored without magnet: {score_normal}")
+    print(f"Scored with magnet: {score_magnet}")
+
+
+if __name__ == "__main__":
+    main()

--- a/smart_ball/__init__.py
+++ b/smart_ball/__init__.py
@@ -1,0 +1,5 @@
+"""Smart ball physics package."""
+
+from .physics import Ball, Hoop, simulate
+
+__all__ = ["Ball", "Hoop", "simulate"]

--- a/smart_ball/physics.py
+++ b/smart_ball/physics.py
@@ -1,0 +1,106 @@
+"""Basic physics engine for the magnetically assisted smart ball."""
+
+from __future__ import annotations
+
+import numpy as np
+
+MU0 = 4e-7 * np.pi  # vacuum permeability
+
+
+class Ball:
+    """State of the basketball."""
+
+    def __init__(
+        self,
+        position: tuple[float, float],
+        velocity: tuple[float, float],
+        radius: float = 0.12,
+        mass: float = 0.62,
+        susceptibility: float = 0.01,
+    ) -> None:
+        self.pos = np.array(position, dtype=float)
+        self.vel = np.array(velocity, dtype=float)
+        self.radius = radius
+        self.mass = mass
+        self.susceptibility = susceptibility
+        self.volume = 4 / 3 * np.pi * radius ** 3
+
+
+class Hoop:
+    """Hoop with an electromagnetic coil."""
+
+    def __init__(
+        self,
+        center: tuple[float, float],
+        radius: float = 0.23,
+        turns: int = 200,
+        current: float = 0.0,
+    ) -> None:
+        self.center = np.array(center, dtype=float)
+        self.radius = radius
+        self.turns = turns
+        self.current = current
+
+    def magnetic_field(self, pos: np.ndarray) -> float:
+        """Approximate magnetic field at a given position.
+
+        Uses the on-axis field of a current loop with radius ``self.radius``.
+        The distance ``r`` is measured from the centre of the hoop.
+        """
+
+        r = np.linalg.norm(pos - self.center)
+        return MU0 * self.turns * self.current * self.radius ** 2 / (
+            2 * (self.radius ** 2 + r ** 2) ** 1.5
+        )
+
+    def magnetic_force(self, ball: Ball) -> np.ndarray:
+        """Return the magnetic force on ``ball``."""
+
+        B = self.magnetic_field(ball.pos)
+        magnitude = (B ** 2 * ball.volume * ball.susceptibility) / (2 * MU0)
+        r_vec = self.center - ball.pos
+        r = np.linalg.norm(r_vec)
+        if r == 0:
+            return np.zeros(2)
+        return magnitude * r_vec / r
+
+    def check_score(self, prev_pos: np.ndarray, curr_pos: np.ndarray, ball_radius: float) -> bool:
+        """Check if the ball passed through the hoop between two positions."""
+
+        if prev_pos[1] >= self.center[1] and curr_pos[1] < self.center[1]:
+            if abs(curr_pos[0] - self.center[0]) < (self.radius - ball_radius):
+                return True
+        return False
+
+
+def simulate(
+    ball: Ball,
+    hoop: Hoop,
+    dt: float = 0.01,
+    t_max: float = 5.0,
+    magnet: bool = True,
+):
+    """Simulate ``ball`` in the presence of ``hoop``.
+
+    Returns the trajectory (``N``\ x\ ``2`` array) and a boolean indicating
+    whether the shot scored.
+    """
+
+    positions = [ball.pos.copy()]
+    prev_pos = ball.pos.copy()
+    scored = False
+    steps = int(t_max / dt)
+    for _ in range(steps):
+        force = np.array([0.0, -9.81 * ball.mass])
+        if magnet and hoop.current != 0:
+            force += hoop.magnetic_force(ball)
+        ball.vel += force / ball.mass * dt
+        ball.pos += ball.vel * dt
+        positions.append(ball.pos.copy())
+        if hoop.check_score(prev_pos, ball.pos, ball.radius):
+            scored = True
+            break
+        prev_pos = ball.pos.copy()
+        if ball.pos[1] < -1.0:  # hit the ground
+            break
+    return np.array(positions), scored


### PR DESCRIPTION
## Summary
- implement smart_ball physics module modelling ball, hoop and magnetic forces
- add demo script to compare normal vs magnet-assisted trajectories
- document how to run the simulation

## Testing
- `python scripts/run_simulation.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install numpy matplotlib` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8813b008320989abcd78b99dbb3